### PR TITLE
refresh2022q2: version bump to v9.4.0

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=gcc
 _distname=$pkg_name
 pkg_origin=core
-pkg_version=9.3.0
+pkg_version=9.4.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 The GNU Compiler Collection (GCC) is a compiler system produced by the GNU \
@@ -12,7 +12,7 @@ systems.\
 pkg_upstream_url="https://gcc.gnu.org/"
 pkg_license=('GPL-3.0-or-later' 'GCC Runtime Library Exception')
 pkg_source="http://ftp.gnu.org/gnu/$_distname/${_distname}-${pkg_version}/${_distname}-${pkg_version}.tar.xz"
-pkg_shasum="71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1"
+pkg_shasum=c95da32f440378d7751dd95533186f7fc05ceb4fb65eb5b85234e6299eb9838e
 pkg_deps=(
   core/glibc
   core/zlib


### PR DESCRIPTION
package upgraded to v9.4.0; issue https://github.com/habitat-sh/core-plans/issues/4044

Signed-off-by: Nimit <nimit.jyotiana@hotmail.com>